### PR TITLE
[fix-kafka-startup] - Fix kafka not starting automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/files/kafka.service
+++ b/files/kafka.service
@@ -5,9 +5,10 @@ After=zookeeper.service
 [Service]
 Type=simple
 User=kafka
+Environment=JAVA_HOME=/opt/java
 ExecStart=/bin/sh -c '/opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties > /opt/kafka/kafka.log 2>&1'
 ExecStop=/opt/kafka/bin/kafka-server-stop.sh
-Restart=on-abnormal
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/files/zookeeper.service
+++ b/files/zookeeper.service
@@ -5,9 +5,10 @@ After=network.target remote-fs.target
 [Service]
 Type=simple
 User=kafka
+Environment=JAVA_HOME=/opt/java
 ExecStart=/opt/kafka/bin/zookeeper-server-start.sh /opt/kafka/config/zookeeper.properties
 ExecStop=/opt/kafka/bin/zookeeper-server-stop.sh
-Restart=on-abnormal
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/java/tasks/main.yaml
+++ b/roles/java/tasks/main.yaml
@@ -5,7 +5,7 @@
     dest: /opt/
     remote_src: yes
 
-- name: symlink kafka to kafka version
+- name: symlink java to java version
   ansible.builtin.file:
     src: /opt/jre1.8.0_281
     dest: /opt/java

--- a/roles/kafkabroker/tasks/main.yml
+++ b/roles/kafkabroker/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Make sure kafka is running
+- name: Start the kafka service
   ansible.builtin.systemd:
     state: started
     name: kafka

--- a/roles/prep/tasks/main.yml
+++ b/roles/prep/tasks/main.yml
@@ -20,12 +20,12 @@
     dest: /opt/kafka
     state: link
 
-- name: Copy zookeeper service file
+- name: Copy zookeeper unit service file
   ansible.builtin.copy:
     src: files/zookeeper.service
     dest: /etc/systemd/system/zookeeper.service
 
-- name: Copy kafka service file
+- name: Copy kafka unit service file
   ansible.builtin.copy:
     src: files/kafka.service
     dest: /etc/systemd/system/kafka.service


### PR DESCRIPTION
:hammer_and_pick: @givasthefirst 

# Changelog
- Add the java home variable environment in the systemd unit files (kafka and zookeeper)
- Add .gitigone
- Enhance ansible task names
- Change the restart policy to **on-failure** to cover more unclean scenarios, see table below from systemd docs.
![image](https://user-images.githubusercontent.com/6811202/106363968-152e5180-632c-11eb-8611-3c819a990fc6.png)


# How to test it
- [ ] Switch to this branch **fix-kafka-startup**
- [ ] Execute: `vagrant up`
- [ ] Verify that kafka and zookeeper are running
```shell
systemctl status kafka zookeeper
```
